### PR TITLE
Updated link to point to the siteUrl instead of the baseUrl

### DIFF
--- a/public/themes/ot/default/views/layouts/layout.phtml
+++ b/public/themes/ot/default/views/layouts/layout.phtml
@@ -40,7 +40,7 @@ echo "\n";
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a class="brand" href="<?php echo $this->baseUrl(); ?>"><?php echo $this->configVar('appTitle'); ?></a>
+              <a class="brand" href="<?php echo Zend_Registry::get('siteUrl'); ?>"><?php echo $this->configVar('appTitle'); ?></a>
 
               <div class="nav-collapse collapse">
                   <p class="navbar-text pull-right">


### PR DESCRIPTION
baseUrl isn't always set, so changing this to the siteUrl will ensure that the appTitle always links to the homepage of the app.
